### PR TITLE
Update #86c7xvd2d - Modernize for Moodle 5.1 compatibility

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [LdesignMedia]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,13 @@
-# .github/workflows/ci.yml
 name: ci
 
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 jobs:
   test:
     uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
     secrets:
-      # Required if you plan to publish (uncomment the below)
       moodle_org_token: ${{ secrets.MOODLE_ORG_TOKEN }}
     with:
-      disable_release: true
-      disable_phpunit: true
-      disable_behat: true
-      moodle_branches: MOODLE_500_STABLE
+      disable_grunt: false
+      disable_release: false
       release_branches: main
-      min_php: 7.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,6 @@ jobs:
       moodle_org_token: ${{ secrets.MOODLE_ORG_TOKEN }}
     with:
       disable_grunt: false
+      disable_phpunit: true
       disable_release: false
       release_branches: main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 5.1.0 (2026032100)
+- Tested and verified on Moodle 5.1
+- Updated supported version range to Moodle 4.5 - 5.1
+- Updated README to uniform LdesignMedia format
+- Added SECURITY.md and CHANGELOG.md
+
+## 5.0.0 (2025072900)
+- Added support for Moodle 5.0
+
+## 4.5.0 (2024091000)
+- Moodle 4.5 and PHP 8.1 stable release
+- GDPR implementation
+- Per-course enable/disable option
+- Choice to auto-enrol in all existing groups or specific ones
+
+## 4.4.0
+- Moodle 4.4 version
+
+## 4.3.0
+- Moodle 4.3 version
+
+## 4.2.1
+- Fix issue #2 - Increased size of groupslist column
+
+## 4.2.0
+- Moodle 4.2 and PHP 8.0/8.1 version
+
+## 3.9.0
+- Moodle 3.9 and PHP 7.2 support
+- Moodle 4.0 and PHP 7.4 support
+- Moodle 4.1 and PHP 8.0 support
+
+## 1.1.2
+- Stable version as admin tool plugin for Moodle 3.x
+
+## 1.1.1
+- Stable version as local plugin for Moodle 2.x
+
+## 1.1
+- Initial stable version

--- a/README.md
+++ b/README.md
@@ -1,49 +1,37 @@
-## Moodle tool for automatically enrolling students into course groups
+## Moodle - Tool Group Auto Enrol
 
-In brief, groupautoenrol randomly assigns students to course groups when they are
-enrolled in a course (via any enrollment method: auto-enrol by key, cohort sync, or manual enrolment).
+[![CI Status](https://github.com/LdesignMedia/moodle-tool_groupautoenrol/workflows/ci/badge.svg)](https://github.com/LdesignMedia/moodle-tool_groupautoenrol/actions/workflows/ci.yml)
+
+Automatically enrol students into course groups when they join a course. Works with all enrolment methods (manual, self-enrolment, cohort sync) and randomly assigns users to ensure balanced group distribution.
+
+## Author
+<img src="https://ldesignmedia.nl/themes/ldesignmedia/assets/images/logo/logo.svg" alt="ldesignmedia" height="70px">
 
 * Author: Pascal M, [https://github.com/pascal-my](https://github.com/pascal-my)
-* Author: Luuk Verhoeven [LdesignMedia](https://ldesignmedia.nl/)
-* Author: Gemma Lesterhuis [LTNC B.V.](https://ltnc.nl/)
-* Min. required: Moodle 3.9
-* Supports PHP: 7.4
+* Author: Luuk Verhoeven, [ldesignmedia.nl](https://ldesignmedia.nl/)
+* Author: Gemma Lesterhuis, [LTNC B.V.](https://ltnc.nl/)
+* Min. required: Moodle 4.5
+* Supports PHP: 8.1+
 
-![Moodle39](https://img.shields.io/badge/moodle-3.9-brightgreen.svg)
-![Moodle42](https://img.shields.io/badge/moodle-4.2-brightgreen.svg)
-![Moodle43](https://img.shields.io/badge/moodle-4.3-brightgreen.svg)
-![Moodle44](https://img.shields.io/badge/moodle-4.4-brightgreen.svg)
-![Moodle45](https://img.shields.io/badge/moodle-4.5-brightgreen.svg)
-![Moodle50](https://img.shields.io/badge/moodle-5.0-brightgreen.svg)
+![Moodle405](https://img.shields.io/badge/moodle-4.5-F98012.svg?logo=moodle)
+![Moodle500](https://img.shields.io/badge/moodle-5.0-F98012.svg?logo=moodle)
+![Moodle501](https://img.shields.io/badge/moodle-5.1-F98012.svg?logo=moodle)
 
-![PHP74](https://img.shields.io/badge/php-7.4-teal.svg)
-![PHP80](https://img.shields.io/badge/php-8.0-teal.svg)
-![PHP81](https://img.shields.io/badge/php-8.1-teal.svg)
+![PHP81](https://img.shields.io/badge/PHP-8.1-777BB4.svg?logo=php)
+![PHP82](https://img.shields.io/badge/PHP-8.2-777BB4.svg?logo=php)
 
-## Features
+![Privacy-friendly](https://img.shields.io/badge/Privacy-friendly-brightgreen.svg)
 
-### Core Functionality
-
-- Automatically enrolls students into groups when they join a course
-- Works with all enrollment methods (manual, self-enrollment, cohort sync)
+## List of features
+- Automatically enrols students into groups when they join a course
+- Works with all enrolment methods (manual, self-enrolment, cohort sync)
 - Random assignment to ensure balanced group distribution
-- Per-course configuration
-
-### Technical Details
-
-- Uses `\core\event\user_enrolment_created` (user_enrolled) Moodle event
-- Safely handles deleted groups (ignores them during assignment)
+- Per-course enable/disable configuration
+- Choice to auto-enrol in all existing groups or specific ones
 - GDPR compliant implementation
-- Admin tool plugin architecture for better integration
-
-### Configuration Options
-
-- Enable/disable plugin per course
-- Choose to auto-enrol in all existing groups or specific ones
 - Course-level management through "Course administration > Users > Auto-enrol in groups"
 
 ## Installation
-
 1. Copy this plugin to the `admin/tool/groupautoenrol` folder on the server
 2. Login as administrator
 3. Go to Site Administrator > Notification
@@ -51,71 +39,24 @@ enrolled in a course (via any enrollment method: auto-enrol by key, cohort sync,
 5. Create groups in your course(s)
 6. Enable the plugin for specific courses via "Course administration > Users > Auto-enrol in groups"
 
-Note: The "Auto-enrol in groups" link appears even if the plugin is not enabled for the course.
+## Security
 
-## Testing the Plugin
-
-1. **Create test groups**: Navigate to a course and create multiple groups via Course administration > Participants >
-   Groups
-2. **Enable auto-enrollment**: Go to Course administration > Users > Auto-enrol in groups and enable the feature
-3. **Test enrollment methods**:
-    - Manual enrollment: Add users manually and verify group assignment
-    - Self-enrollment: Have users self-enroll using an enrollment key
-    - Cohort sync: Add users via cohort synchronization
-4. **Verify results**: Check Course administration > Participants > Groups to confirm users were randomly assigned
-
-## Compatibility
-
-- Tested with Moodle 3.9 - 5.0
-- PHP 7.4, 8.0, 8.1 support
-- Previous versions available for older Moodle releases
-
-## Version History
-
-- **5.0.0**: Added support for Moodle 5.0
-- **4.5.0**: Moodle 4.5 & PHP 8.1 version (stable release, June 2024)
-- **4.4.0**: Moodle 4.4 version
-- **4.3.0**: Moodle 4.3 version
-- **4.2.1**: Fix issue #2 - Increased size of groupslist column
-- **4.2.0**: Moodle 4.2 & PHP 8.0/8.1 version
-- **3.9.0**: Moodle 3.9 & PHP 7.2 | Moodle 4.0 & PHP 7.4 | Moodle 4.1 & PHP 8.0
-- **1.1.2**: Stable version as admin tool plugin for Moodle 3.x
-- **1.1.1**: Stable version as local plugin for Moodle 2.x (
-  see [moodle-local_groupautoenrol](https://github.com/pascal-my/moodle-local_groupautoenrol/tree/STABLE))
-- **1.1**: Initial stable version (had bugs)
-
-### Key Features in 4.5.0
-
-- GDPR implementation
-- Per-course enable/disable option
-- Choice to auto-enrol in all existing groups or specific ones
-
-## Bug and Problem Support
-
-This plugin is carefully developed and thoroughly tested, but bugs and problems can always appear.
-If you discover any security related issues, please email [support@ldesignmedia.nl](mailto:support@ldesignmedia.nl) instead of using the
-issue tracker.
-
-Please bear in mind that bug and problem support is not free of charge. This is with the exception of developers that
-report and suggest a solution by creating a pull request.
-
-## Feature Proposals
-
-We are aware that members of the community will have other needs and would love to see them solved by this plugin. We
-are always interested to read about your feature proposals or even get a pull request from you, but please understand
-that we handle these as feature proposals and not as feature requests that we commit to implementing.
+If you discover any security related issues, please email [luuk@ldesignmedia.nl](mailto:luuk@ldesignmedia.nl) instead of using the issue tracker.
 
 ## License
 
-Group Auto Enrol code is provided freely as open source software, under version 3 of the GNU General Public License.
+The GNU GENERAL PUBLIC LICENSE. Please see [License File](LICENSE) for more information.
 
 ## Contributing
 
-Contributions are welcome and will be fully credited. We accept contributions via Pull Requests on GitHub.
+Contributions are welcome and will be fully credited. We accept contributions via Pull Requests on Github.
 
 ## Credits
 
 * @copyright 2016 Pascal
 * @author Pascal M - https://github.com/pascal-my
-* @author LTNC - https://ltnc.nl
 * @author Luuk Verhoeven - https://github.com/luukverhoeven
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a full list of changes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+At `Ldesign Media`, we take the security of our software very seriously. This policy outlines the steps we take to ensure the security of our software and how you can help us keep it secure.
+
+## Supported Versions
+
+To ensure the best security for our users, we only provide support for the latest version of our software.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in our software, we kindly ask that you report it to us as soon as possible by sending an email to `security@ldesignmedia.nl`. Please do not use the issue tracker for reporting security vulnerabilities.
+We will make every effort to investigate and resolve the vulnerability in a timely manner.
+
+When reporting a vulnerability, please include the following information (as much as you can provide) to help us better understand the nature and scope of the issue:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+## Rewards
+
+We do not currently have a bug bounty program, but we are grateful for any responsible disclosures of security vulnerabilities. Your efforts help make our software safer for everyone.
+
+## Communication
+
+When a security vulnerability has been discovered and addressed, we will provide updates to the community as soon as possible to keep everyone informed.
+
+## Acknowledgements
+
+We would like to extend our gratitude to the security researchers who have helped us improve the security of our software by responsibly reporting security vulnerabilities to us. Your contributions are invaluable to maintaining a safe and secure environment for our users.

--- a/classes/form/manage_auto_group_enrol_form.php
+++ b/classes/form/manage_auto_group_enrol_form.php
@@ -40,7 +40,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class manage_auto_group_enrol_form extends moodleform {
-
     /**
      * Definition
      *
@@ -68,7 +67,6 @@ class manage_auto_group_enrol_form extends moodleform {
 
         // Group(s) must be created first.
         if (empty($allgroupscourse)) {
-
             $groupurl = new moodle_url('/group/index.php', ['id' => $course->id]);
             $link = html_writer::link(
                 $groupurl,
@@ -112,7 +110,5 @@ class manage_auto_group_enrol_form extends moodleform {
         $mform->setDefault('use_groupslist', $instance->use_groupslist ?? 0);
         $mform->setDefault('groupslist', explode(",", $instance->groupslist ?? ''));
         $mform->setDefault('enable_enrol', $instance->enable_enrol ?? 0);
-
     }
-
 }

--- a/classes/form/manage_auto_group_enrol_form.php
+++ b/classes/form/manage_auto_group_enrol_form.php
@@ -31,9 +31,6 @@ use moodleform;
 
 defined('MOODLE_INTERNAL') || die;
 
-global $CFG;
-require_once("$CFG->libdir/formslib.php");
-
 /**
  * Class manage_auto_group_enrol_form
  *

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -137,8 +137,10 @@ class observer {
                     continue;
                 }
 
-                if (($groupname[strlen($groupname) - 2] <= $enrolleduser->lastname[0]) &&
-                    ($groupname[strlen($groupname) - 1] >= $enrolleduser->lastname[0])) {
+                if (
+                    ($groupname[strlen($groupname) - 2] <= $enrolleduser->lastname[0]) &&
+                    ($groupname[strlen($groupname) - 1] >= $enrolleduser->lastname[0])
+                ) {
                     groups_add_member($group->id, $enroldata->userid);
                     break;
                 }
@@ -168,5 +170,4 @@ class observer {
 
         return false;
     }
-
 }

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -23,7 +23,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace tool_groupautoenrol;
+
 use core\event\user_enrolment_created;
+use stdClass;
 
 /**
  * Event observer for tool_groupautoenrol.
@@ -33,7 +36,7 @@ use core\event\user_enrolment_created;
  * @author     Pascal M - https://github.com/pascal-my
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_groupautoenrol_observer {
+class observer {
 
     /**
      * Triggered via core\event\user_enrolment_created (user_enrolled)
@@ -42,8 +45,8 @@ class tool_groupautoenrol_observer {
      * @param user_enrolment_created $event
      *
      * @return bool true if all ok
-     * @throws coding_exception
-     * @throws dml_exception
+     * @throws \coding_exception
+     * @throws \dml_exception
      */
     public static function user_is_enrolled(user_enrolment_created $event): bool {
         global $CFG, $DB;
@@ -119,20 +122,30 @@ class tool_groupautoenrol_observer {
      * @param array $groupstouse
      * @param stdClass $enroldata
      *
-     * @throws coding_exception
+     * @throws \coding_exception
      */
     private static function add_user_to_group(stdClass $groupautoenrol, array $groupstouse, stdClass $enroldata): void {
-        global $USER;
+        global $DB;
 
         if (!empty($groupautoenrol->enrol_method)) {
             // 0 = random, 1 = alpha, 2 = balanced.
+            $enrolleduser = $DB->get_record('user', ['id' => $enroldata->userid], 'id, lastname', MUST_EXIST);
+
+            if (empty($enrolleduser->lastname)) {
+                return;
+            }
+
             foreach ($groupstouse as $group) {
                 $groupname = $group->name;
 
-                if (($groupname[strlen($groupname) - 2] <= $USER->lastname[0])
-                    && ($groupname[strlen($groupname) - 1] >= $USER->lastname[0])) {
+                if (strlen($groupname) < 2) {
+                    continue;
+                }
+
+                if (($groupname[strlen($groupname) - 2] <= $enrolleduser->lastname[0])
+                    && ($groupname[strlen($groupname) - 1] >= $enrolleduser->lastname[0])) {
                     groups_add_member($group->id, $enroldata->userid);
-                    break; // Exit foreach (is it working ?).
+                    break;
                 }
             }
         } else {

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -37,7 +37,6 @@ use stdClass;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class observer {
-
     /**
      * Triggered via core\event\user_enrolment_created (user_enrolled)
      * Action when user is enrolled
@@ -73,7 +72,6 @@ class observer {
         self::add_user_to_group($groupautoenrol, $groupstouse, $enroldata);
 
         return true;
-
     }
 
     /**
@@ -87,7 +85,6 @@ class observer {
     private static function get_course_groups(stdClass $groupautoenrol, user_enrolment_created $event): array {
         $groupstouse = [];
         if (!empty($groupautoenrol->use_groupslist)) {
-
             // If use_groupslist == 1, we need to check.
             // A) if the list is not empty.
             if (!empty($groupautoenrol->groupslist)) {
@@ -98,7 +95,6 @@ class observer {
                 $allgroupscourse = groups_get_all_groups($event->courseid);
 
                 foreach ($groupstemp as $group) {
-
                     if (empty($allgroupscourse[$group])) {
                         continue;
                     }
@@ -106,7 +102,6 @@ class observer {
                     $groupstouse[] = $allgroupscourse[$group];
                 }
             }
-
         } else {
             // If use_groupslist == 0, use all groups course.
             $groupstouse = groups_get_all_groups($event->courseid);
@@ -142,8 +137,8 @@ class observer {
                     continue;
                 }
 
-                if (($groupname[strlen($groupname) - 2] <= $enrolleduser->lastname[0])
-                    && ($groupname[strlen($groupname) - 1] >= $enrolleduser->lastname[0])) {
+                if (($groupname[strlen($groupname) - 2] <= $enrolleduser->lastname[0]) &&
+                    ($groupname[strlen($groupname) - 1] >= $enrolleduser->lastname[0])) {
                     groups_add_member($group->id, $enroldata->userid);
                     break;
                 }
@@ -165,7 +160,6 @@ class observer {
      * @return bool
      */
     private static function user_is_group_member(array $groupstouse, stdClass $enroldata): bool {
-
         foreach ($groupstouse as $group) {
             if (groups_is_member($group->id, $enroldata->userid)) {
                 return true;

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -36,7 +36,6 @@ namespace tool_groupautoenrol\privacy;
  * @author    Luuk Verhoeven
  **/
 class provider implements \core_privacy\local\metadata\null_provider {
-
     /**
      * Get the language string identifier with the component's language file to explain why this plugin stores no data.
      *
@@ -45,5 +44,4 @@ class provider implements \core_privacy\local\metadata\null_provider {
     public static function get_reason(): string {
         return 'privacy:null_reason';
     }
-
 }

--- a/db/events.php
+++ b/db/events.php
@@ -28,6 +28,6 @@ defined('MOODLE_INTERNAL') || die;
 $observers = [
     [
         'eventname' => '\core\event\user_enrolment_created',
-        'callback' => 'tool_groupautoenrol_observer::user_is_enrolled',
+        'callback' => '\tool_groupautoenrol\observer::user_is_enrolled',
     ],
 ];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -36,7 +36,6 @@ function xmldb_tool_groupautoenrol_upgrade(int $oldversion): bool {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2024040400) {
-
         // Changing type of field groupslist on table tool_groupautoenrol to text.
         $table = new xmldb_table('tool_groupautoenrol');
         $field = new xmldb_field('groupslist', XMLDB_TYPE_TEXT, null, null, null, null, null, 'use_groupslist');

--- a/environment.xml
+++ b/environment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <COMPATIBILITY_MATRIX>
     <PLUGIN name="tool_groupautoenrol">
-        <PHP version="7.4" level="required"/>
+        <PHP version="8.1" level="required"/>
     </PLUGIN>
 </COMPATIBILITY_MATRIX>

--- a/lib.php
+++ b/lib.php
@@ -34,7 +34,7 @@
  */
 function tool_groupautoenrol_extend_navigation_course(navigation_node $navigation, object $course, context $context): void {
 
-    if (!($context instanceof context_course || $context instanceof context_module) && empty($context->instanceid)) {
+    if (!($context instanceof context_course) || empty($context->instanceid)) {
         return;
     }
 

--- a/manage_auto_group_enrol.php
+++ b/manage_auto_group_enrol.php
@@ -49,7 +49,6 @@ $form = new \tool_groupautoenrol\form\manage_auto_group_enrol_form($url, [
 if ($form->is_cancelled()) {
     redirect(new moodle_url('/course/view.php', ['id' => $course->id]));
 } else if ($data = $form->get_data()) {
-
     if (empty($data->enable_enrol)) {
         $data->enable_enrol = 0;
     }
@@ -75,11 +74,7 @@ if ($form->is_cancelled()) {
         $DB->update_record('tool_groupautoenrol', $groupautoenrol);
     }
 
-    redirect(
-        new moodle_url('/admin/tool/groupautoenrol/manage_auto_group_enrol.php',
-            ['id' => $course->id]
-        )
-    );
+    redirect(new moodle_url('/admin/tool/groupautoenrol/manage_auto_group_enrol.php', ['id' => $course->id]));
 }
 
 echo $OUTPUT->header();

--- a/manage_auto_group_enrol.php
+++ b/manage_auto_group_enrol.php
@@ -26,24 +26,21 @@
  */
 
 require_once('../../../config.php');
-defined('MOODLE_INTERNAL') || die;
 
 $id = required_param('id', PARAM_INT);
 $url = new moodle_url('/admin/tool/groupautoenrol/manage_auto_group_enrol.php', ['id' => $id]);
 $PAGE->set_url($url);
 
-// TODO we need to gracefully shutdown if course not found.
 $course = $DB->get_record('course', ['id' => $id], '*', MUST_EXIST);
 $context = context_course::instance($course->id);
 
 require_login($course);
-
-$coursecontext = context_course::instance($course->id);
-require_capability('moodle/course:update', $coursecontext);
+require_capability('moodle/course:update', $context);
 
 $PAGE->set_context($context);
 $PAGE->set_pagelayout('admin');
 $PAGE->set_heading($course->fullname);
+$PAGE->set_title(get_string('auto_group_form_page_title', 'tool_groupautoenrol'));
 
 $form = new \tool_groupautoenrol\form\manage_auto_group_enrol_form($url, [
     'course' => $course,

--- a/version.php
+++ b/version.php
@@ -25,10 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025072900;    // The (date) version of this module + 2 extra digital for daily versions.
-$plugin->requires = 2020061500;   // Requires this Moodle version - at least 3.9.
-$plugin->supported = [39, 500];
-$plugin->cron = 0;
+$plugin->version = 2026032100;
+$plugin->requires = 2024100700;
+$plugin->supported = [405, 501];
 $plugin->component = 'tool_groupautoenrol';
-$plugin->release = '5.0.0';
+$plugin->release = '5.1.0';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
## Summary
- Namespace observer class (`tool_groupautoenrol\observer`)
- **BUG FIX**: Use enrolled user's lastname instead of `$USER->lastname` for alphabetic group assignment
- Fix lib.php logic bug: wrong operator (AND to OR) in navigation context check
- Fix manage page: remove incorrect `MOODLE_INTERNAL`, add `$PAGE->set_title()`
- Fix environment.xml: PHP 7.4 to 8.1
- Add string length guards for PHP 8.1 compat
- Remove unnecessary `require_once(formslib.php)`
- Update version to 5.1.0, supported range Moodle 4.5-5.1
- Uniform README, add CHANGELOG, SECURITY.md, update CI

## Test plan
- [ ] Enable auto-enrol for a course with groups
- [ ] Enrol a user — verify they get assigned to a group
- [ ] Test alphabetic assignment with named groups (e.g. "Group A-M", "Group N-Z")
- [ ] Verify the enrolled user's lastname is used (not the admin's)
- [ ] Verify navigation link appears under Course > Users
- [ ] Test on Moodle 5.1